### PR TITLE
docs: reorganize README as landing page, add quickstart guide, improve navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - **Remote Broker Deployment** section in README with docker-compose and standalone examples.
 
 ### Changed
+- **Documentation reorganization**: Rewrote `README.md` as a clean landing page with table of contents, visible documentation navigation, and generic service-oriented hostnames (`<llm-host>`, `<embedding-host>`, `<vector-db-host>`, etc.). Moved detailed environment configuration, distributed deployment diagram, and hardware profile into a new `docs/quickstart.md`. Removed all LAN-specific hostnames and IP addresses from README. Moved cross-document navigation links from bottom to top of all docs for consistent discoverability.
 - **`doc-ingest-chat/config/settings.py` refactored to thin wrapper**: All 83 settings, helper functions, and lazy-loading logic moved to `shared/config.py`. `config/settings.py` now imports `_SETTINGS` from shared and re-exports via `__getattr__` — all existing `from config.settings import X` imports continue working unchanged.
 - **`config/llama_strategy.py` and `config/env_strategy.py`**: Updated to import env names and defaults from `shared/` instead of hardcoded strings. Added sys.path fix for Docker containers where `shared/` is at `/app/shared/`.
 - **Dockerfile updates**: `Dockerfile.worker` and `Dockerfile.worker.inprogress` now copy `shared/` into `/app/shared/`.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,36 @@
 # Self-Hosted RAG Pipeline
 
-**A distributed document processing and RAG chat system built for commodity hardware. Every component — LLMs, embeddings, Whisper transcription, OCR, vector database — runs as a standalone service on a separate minipc or container, communicating over the local network. Fully air-gapped, zero internet dependency.**
+A self-hosted retrieval augmented generation pipeline that ingests PDFs, videos, and audio files and serves them through a chat interface with clickable source citations. The system runs entirely on local hardware without external dependencies. Files are routed by type through a chain of content handlers. PDFs are processed with pdfplumber and automatic OCR fallback handles scanned pages. Media files are transcribed with WhisperX. Raw text formats are read directly. A supervisor LLM normalizes all extracted text to Markdown with page anchors. The producer splits the normalized content on header boundaries, generates embeddings, and stores the resulting vector chunks in Qdrant.
+
+Compute workloads are separated into individual HTTP services so embedding generation, LLM inference, WhisperX transcription, and OCR can each run on different hosts. Redis-backed queues with backpressure coordinate ingestion across all services. Ingestion and querying run concurrently so already processed documents are available in chat while others continue ingesting. Hardware can range from an N100 minipc to a split inference setup with a Ryzen 7 7840HS and an RTX 3060 connected over OCuLink in one Proxmox LXC with the 780M iGPU in another. The chat UI retrieves relevant chunks from Qdrant and returns LLM responses with citations linking back to the source page.
+
+**Technologies**: Python, llama-cpp, FastAPI, Redis, DuckDB, Qdrant/Chroma, WhisperX, Docling, Docker Compose, Astro, Tailwind CSS
 
 ![Self Hosted Rag Doc Pipeline](./docs/selfhosted-rag-doc-ingest.gif)
 
 ---
 
-## Architecture at a Glance
+## Contents
+
+- [What It Does](#what-it-does)
+- [How It Works](#how-it-works)
+- [Documentation](#documentation)
+- [Quick Start](#quick-start)
+
+---
+
+## What It Does
+
+- **Multi-format ingestion**: Drop PDFs, HTML, Markdown, MP3, MP4, WAV files into a staging folder. Each file type is routed to the correct handler automatically.
+- **Markdown-first normalization**: All raw text is normalized into clean, structured Markdown with page anchors before chunking. Noisy footers, page numbers, and OCR artifacts are stripped.
+- **Zero-drop chunking**: Hierarchical splitting preserves document structure. Oversized chunks are sub-split rather than truncated. Deterministic IDs via MurmurHash3 prevent duplication on re-ingestion.
+- **Semantic search**: Embeddings via mxbai or e5 models, stored in Qdrant (or Chroma). Asymmetric search with `query:` and `passage:` prefixes for accurate retrieval.
+- **RAG chat with citations**: Query your documents via a chat UI. Every answer sentence is traced back to its source with clickable citations linking to the original file and page.
+- **Distributed, air-gapped**: Every service runs on dedicated LAN hosts. No internet dependency. HuggingFace offline mode baked into all containers.
+
+---
+
+## How It Works
 
 ```
 staging/ → Gatekeeper (extract + normalize to Markdown) → Producer (chunk + enqueue)
@@ -16,199 +40,57 @@ staging/ → Gatekeeper (extract + normalize to Markdown) → Producer (chunk + 
 
 ![Flow](./docs/arch.png)
 
-All heavy models run as remote API endpoints. Workers connect to them over HTTP. Every file is tracked through a DuckDB-backed state machine with atomic per-file handoffs, ensuring zero partial ingestions and crash-safe recovery.
+1. **Gatekeeper**: A chain of responsibility routes each file to the correct handler. PDFs get pdfplumber extraction with automatic OCR fallback for scanned pages. Media files get WhisperX transcription. Raw text from all sources is normalized to clean Markdown by a supervisor LLM.
+
+2. **Producer**: Normalized Markdown is split into 512-token chunks using hierarchical header boundaries. Each chunk gets a deterministic `[DOC_XXXX]` ID and is enqueued to Redis.
+
+3. **Consumer**: Chunks are staged in DuckDB for safety, then embedded and batch-upserted to Qdrant atomically per file. Files move to `success/` on completion.
+
+4. **Chat**: The FastAPI backend retrieves relevant chunks from Qdrant, formats context with citation tags, and streams an LLM response with clickable source links.
+
+Ingestion and querying are fully concurrent. You can chat with already-processed documents while thousands more are being ingested.
+
+---
+
+## Documentation
+
+| | | |
+|---|---|---|
+| **[Quick Start](docs/quickstart.md)** | Full environment configuration, service setup, and deployment diagram |
+| **[Architecture](docs/overview.md)** | System flow, component map, state machine, and Redis queue architecture |
+| **[Deep Dive](docs/deep-dive.md)** | Design rationale, dual-LLM architecture, chunking strategy, production roadmap |
+| **[Operations](docs/operations.md)** | Debugging queries for DuckDB, Redis, and Qdrant. Metrics, schema evolution, war room scenarios |
+| **[Edge Agent](docs/edge-agent.md)** | Deploy MQTT SRE agents on standalone Debian minipcs for telemetry and task execution |
+| **[Changelog](CHANGELOG.md)** | Version history and feature tracking |
 
 ---
 
 ## Quick Start
 
-### 1. Prerequisites
+### Prerequisites
 
-**System dependencies** (baked into the Docker image):
-- `ffmpeg` — audio extraction for WhisperX
-- `poppler-utils` — PDF page rendering
-- `libgl1` / `libglib2.0-0` — OpenCV/vision processing
+- Docker v2.20+
+- Node.js v22.12.0+ (frontend only)
 
-**Docker** (v2.20+) — for the containerized worker stack
-**Node.js v22.12.0+** — for frontend development
+### Configure
 
-### 2. Model Services (All Remote, Any LAN Host)
-
-Every AI workload runs as an HTTP(S) service on a dedicated host. The system auto-detects local-vs-remote from the URL scheme.
-
-| Service | Env Var | Remote Endpoint Format | Example Host |
-|---------|---------|----------------------|-------------|
-| RAG LLM | `LLM_PATH` | `http://<host>:<port>/v1/chat/completions` | lxc-nvidia (GPU) |
-| Supervisor LLM | `SUPERVISOR_LLM_PATH` | `http://<host>:<port>/v1/chat/completions` | lxc-nvidia (GPU) |
-| Embedding | `EMBEDDING_MODEL_PATH` | `http://<host>:<port>/v1/embeddings` | lxc-bee2 |
-| WhisperX | `WHISPER_MODEL_PATH` | `http://<host>:<port>/inference` | lxc-amd |
-| OCR (docling-serve) | `OCR_PATH` | `http://<host>:<port>/v1/convert/file` | lxc-bee3 |
-| Vector DB (Qdrant) | `VECTOR_DB_URL` | `http://<host>:<port>` (gRPC or REST) | lxc-bee1 |
-
-For local testing, any path can point to a local directory or GGUF file instead — the system detects the format automatically.
-
-### 3. Configure Environment
-
-Example configuration with all services on separate LAN hosts:
+Four environment variables are required. Each accepts either a local path (model loaded in-container) or a remote `http(s)://` URL pointing to a service on your LAN:
 
 ```bash
-# REQUIRED — root directory for all lifecycle stages (staging, preprocessing, success, etc.)
-export DEFAULT_DOC_INGEST_ROOT=/home/user/rag-docs
-
-# Qdrant — gRPC on port 6334 (REST also available on 6333)
-export VECTOR_DB_PROFILE=qdrant
-export VECTOR_DB_URL=http://192.168.30.68:6334
-export VECTOR_DB_USE_GRPC=true
-
-# LLMs — llama-server or any OpenAI-compatible API on GPU host
-export LLM_PATH=http://192.168.30.60:11434/v1/chat/completions
-export SUPERVISOR_LLM_PATH=http://192.168.30.60:11434/v1/chat/completions
-
-# Embedding — remote embeddings API
-export EMBEDDING_MODEL_PATH=http://192.168.30.66:11434/v1/embeddings
-
-# WhisperX — transcription service
-export WHISPER_MODEL_PATH=http://192.168.30.70:1145/inference
-
-# OCR — docling-serve (set to LOCAL for inline Docling)
-export OCR_PATH=http://192.168.30.69:5001/v1/convert/file
-
-# Force OCR on all PDF pages (skip pdfplumber)
-export PDF_FORCE_OCR=true
+export DEFAULT_DOC_INGEST_ROOT=/path/to/docs
+export LLM_PATH=http://<llm-host>:11434/v1/chat/completions
+export SUPERVISOR_LLM_PATH=http://<llm-host>:11434/v1/chat/completions
+export EMBEDDING_MODEL_PATH=http://<embedding-host>:11434/v1/embeddings
 ```
 
-Local-only alternatives (GGUF files / local directories):
-```bash
-export LLM_PATH=/home/user/models/Phi-4-mini-instruct-Q6_K.gguf
-export EMBEDDING_MODEL_PATH=/home/user/models/e5-large-v2
-export WHISPER_MODEL_PATH=/home/user/models/whisper
-export OCR_PATH=LOCAL
-```
+All service endpoints, optional variables, and local-file alternatives are documented in [docs/quickstart.md](docs/quickstart.md).
 
-### 4. Launch
+### Launch
 
 ```bash
 ./doc-ingest-chat/run-compose.sh --build
 ```
 
-The stack starts: Redis → Gatekeeper → Producer → OCR Worker → WhisperX Worker → Consumer → FastAPI backend. Workers connect to remote model services over the LAN.
+### Use
 
-### 5. Drop Files and Watch
-
-Drop PDFs, MP3s, MP4s, HTML, or Markdown files into `$DEFAULT_DOC_INGEST_ROOT/staging/`. The system auto-detects them.
-
-```bash
-docker logs -f gatekeeper_worker   # normalization progress
-docker logs -f consumer_worker     # embedding and Qdrant upsert
-```
-
-### 6. Chat
-
-Open [http://localhost:4321](http://localhost:4321). The UI queries the FastAPI backend (port 8000), which retrieves relevant chunks from Qdrant and streams an LLM response with clickable citations linking back to source documents.
-
----
-
-## Distributed Deployment
-
-Every heavy service runs on a dedicated minipc or container:
-
-```
-┌──────────────┐   ┌──────────────┐   ┌──────────────┐
-│  lxc-nvidia  │   │   lxc-bee2   │   │   lxc-bee1   │
-│  (GPU host)  │   │  (Embedding) │   │   (Qdrant)   │
-│              │   │              │   │              │
-│ LLM + Sup.   │   │  e5-large-v2 │   │  gRPC:6334   │
-│ :11434/v1    │   │  :11434/v1   │   │  REST:6333   │
-└──────────────┘   └──────────────┘   └──────────────┘
-
-┌──────────────┐   ┌──────────────┐
-│   lxc-amd    │   │  lxc-bee3    │
-│  (WhisperX)  │   │   (OCR)      │
-│              │   │              │
-│ :1145/inf.   │   │ docling-serve│
-│              │   │ :5001/v1     │
-└──────────────┘   └──────────────┘
-```
-
-The ingestion worker stack runs on the coordinator host — all heavy compute is offloaded to these services. This allows each minipc to be optimized for its specific workload (GPU for LLM, CPU+RAM for WhisperX, etc.).
-
-### Air-Gapped / Offline by Design
-
-- `HF_HUB_OFFLINE=1` is baked into all Docker images — HuggingFace libraries never phone home
-- Docling OCR models are cached during Docker build-time warmup — no runtime downloads
-- All service URLs are LAN addresses only
-- Worker images are self-contained; no external API calls are made during ingestion or query
-- The entire system operates on a private network with no internet access required
-
----
-
-## Hardware Profile
-
-Each minipc is specced for its workload:
-
-| Host | Role | Key Hardware |
-|------|------|-------------|
-| lxc-nvidia | LLM inference (Phi-4-mini) | NVIDIA GPU via eGPU OCuLink dock |
-| lxc-bee2 | Embedding (e5-large-v2) | Multi-core CPU, 16GB+ RAM |
-| lxc-amd | WhisperX transcription | Multi-core CPU, 16GB+ RAM |
-| lxc-bee3 | Docling OCR | Multi-core CPU, 8GB+ RAM |
-| lxc-bee1 | Qdrant vector DB | NVMe SSD, 8GB+ RAM |
-| Coordinator | Worker stack (ingestion) | Multi-core CPU, 16GB+ RAM |
-
-All services scale horizontally — add more embedding workers behind a load balancer, or more LLM instances for higher query throughput.
-
----
-
-## How Ingestion Works
-
-### Step 1 — Gatekeeper: Extract & Normalize
-
-The Gatekeeper claims files from `staging/`. A **Chain of Responsibility** routes each file to the correct handler:
-
-| Handler | File Types | Extraction Method |
-|---------|-----------|-------------------|
-| `PDFContentTypeHandler` | `.pdf` | `pdfplumber` (fast text-layer check) → OCR fallback via Docling/EasyOCR for scanned pages |
-| `MP4ContentTypeHandler` | `.mp4` | Delegates to WhisperX worker via Redis |
-| `MP3ContentTypeHandler` | `.mp3`, `.wav` | Delegates to WhisperX worker via Redis |
-| `TextContentTypeHandler` | `.txt`, `.md`, `.html` | Direct file read |
-
-Raw text streams from handlers are batched and sent to the **Supervisor LLM** which normalizes the messy raw extraction into clean, structured Markdown with page anchors (`### [INTERNAL_PAGE_X]`). The result is a single `.md` file.
-
-**State transition**: `NEW → PREPROCESSING → PREPROCESSING_COMPLETE`
-
-### Step 2 — Producer: Chunk & Enqueue
-
-The Producer claims the normalized Markdown. It performs hierarchical splitting (H1 → H2 → INTERNAL_PAGE → H3) with a 512-token budget per chunk. Oversized chunks are sub-split rather than truncated (zero-drop policy). Each chunk receives a deterministic `[DOC_XXXX]` ID via MurmurHash3. Chunks and a `file_end` sentinel are pushed to dedicated Redis queues (1:1 queue per consumer for file-level affinity).
-
-**State transition**: `PREPROCESSING_COMPLETE → INGESTING → CONSUMING`
-
-### Step 3 — Consumer: Embed & Persist
-
-The Consumer buffers incoming chunks in DuckDB (acting as a write-ahead log). When the `file_end` sentinel arrives, all chunks for that file are retrieved, embedded via `e5-large-v2`, and upserted into Qdrant as a single atomic batch. Files are then moved to `success/` and chunks committed to Parquet for archival.
-
-**State transition**: `CONSUMING → INGEST_SUCCESS`
-
----
-
-## Hardware Profile
-
-The system is designed for commodity hardware — the reference setup:
-
-| Component | Specification |
-|-----------|--------------|
-| CPU | Intel i9-14900KF (24-core) — or any modern multi-core CPU |
-| GPU | NVIDIA RTX 4070 12GB — or eGPU via OCuLink dock |
-| RAM | 32 GB DDR5 |
-| OS | Ubuntu 22.04+ / Python 3.11 |
-| Storage | NVMe SSD recommended for document throughput |
-
-Performance on this setup: 10-15 PDFs/min (mixed quality), ~400ms query latency (p50), Qdrant tested with 10K+ chunks at sub-second retrieval.
-
----
-
-## Further Reading
-
-- **[docs/overview.md](docs/overview.md)** — Full architecture, lifecycle flow, and component map
-- **[docs/deep-dive.md](docs/deep-dive.md)** — Design rationale, dual-LLM architecture, chunking strategy, production roadmap
-- **[docs/operations.md](docs/operations.md)** — Debugging, DuckDB queries, Redis/Qdrant inspection, metrics
-- **[CHANGELOG.md](CHANGELOG.md)** — Version history and feature tracking
+Drop files into `$DEFAULT_DOC_INGEST_ROOT/staging/`. The system auto-detects and processes them. Open [http://localhost:4321](http://localhost:4321) to chat with your documents.

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -1,6 +1,8 @@
+**[< Overview](overview.md) | [Quick Start](quickstart.md) | [Operations](operations.md)**
+
 # Technical Deep Dive
 
-This document covers design rationale, AI model usage, and production considerations for the Self-Hosted RAG system. For architecture and data flow, see [docs/overview.md](overview.md). For setup, see the [main README](../README.md).
+This document covers design rationale, AI model usage, and production considerations for the Self-Hosted RAG system.
 
 ---
 

--- a/docs/edge-agent.md
+++ b/docs/edge-agent.md
@@ -1,3 +1,5 @@
+**[< MQTT Hub](../mqtt_agent_hub/README.md) | [Overview](overview.md) | [Operations](operations.md)**
+
 # Edge Agent Deployment Guide
 
 Deploy a lightweight MQTT SRE agent on a standalone Debian Linux minipc or edge device. The agent registers with the private MQTT Agent Hub, reports telemetry (CPU, memory, disk, load), executes tasks, and optionally runs a local LLM for autonomous system reliability analysis.
@@ -5,8 +7,6 @@ Deploy a lightweight MQTT SRE agent on a standalone Debian Linux minipc or edge 
 **Two modes of operation:**
 - **Bare mode** (default): MQTT telemetry + task execution — no LLM required
 - **LLM mode** (`LLM_PATH` set): Same as bare, plus periodic LLM-driven analysis using function-calling tools. The agent persona is a read-only SRE that investigates anomalies and reports findings
-
-For hub architecture, see [docs/overview.md](overview.md). For hub operations, see [docs/operations.md](operations.md).
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,6 +1,8 @@
+**[< Architecture](overview.md) | [Deep Dive](deep-dive.md) | [Quick Start](quickstart.md)**
+
 # Operations, Debugging & Metrics
 
-This document covers operational procedures for monitoring, debugging, and maintaining the Self-Hosted RAG system. For architecture, see [docs/overview.md](overview.md).
+This document covers operational procedures for monitoring, debugging, and maintaining the Self-Hosted RAG system.
 
 ---
 
@@ -154,7 +156,7 @@ docker exec -it doc-ingest-chat-redis-1 redis-cli
 ### Point Count for a Document
 
 ```bash
-curl -X POST http://<qdrant-host>:6333/collections/vector_base_collection/points/count \
+curl -X POST http://<vector-db-host>:6333/collections/vector_base_collection/points/count \
   -H "Content-Type: application/json" \
   -d '{
     "filter": {
@@ -163,19 +165,19 @@ curl -X POST http://<qdrant-host>:6333/collections/vector_base_collection/points
   }'
 ```
 
-Replace `<qdrant-host>` with your Qdrant REST API endpoint (default port 6333, or as configured via `VECTOR_DB_URL`).
+Replace `<vector-db-host>` with your Qdrant REST API endpoint (default port 6333, or as configured via `VECTOR_DB_URL`).
 
 ### Sample Payloads
 
 ```bash
-curl -X POST http://<qdrant-host>:6333/collections/vector_base_collection/points/scroll \
+curl -X POST http://<vector-db-host>:6333/collections/vector_base_collection/points/scroll \
   -H "Content-Type: application/json" \
   -d '{"limit": 3, "with_payload": true, "with_vector": false}'
 ```
 
 ### Qdrant Dashboard
 
-Visit `http://<qdrant-host>:6333/dashboard` for the built-in web UI.
+Visit `http://<vector-db-host>:6333/dashboard` for the built-in web UI.
 
 ---
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,8 @@
+**[< Quick Start](quickstart.md) | [< README](../README.md) | [Deep Dive](deep-dive.md) | [Operations](operations.md)**
+
 # Architecture Overview
 
-This document covers the complete system architecture, data flow, and component map for the Self-Hosted RAG Ingestion & Chat system. For setup instructions, see the [main README](../README.md). For deeper technical rationale, see [docs/deep-dive.md](deep-dive.md).
+This document covers the complete system architecture, data flow, and component map for the Self-Hosted RAG Ingestion & Chat system.
 
 ---
 
@@ -137,6 +139,8 @@ Files move through directories on disk, and each move is mirrored by a status up
 | **Producer** | `run_producer.py` | Reads from `ingestion/` | Claims normalized Markdown, splits into chunks with `[DOC_XXXX]` IDs, enqueues to Redis consumer queues, sends `file_end` sentinel |
 | **Consumer** | `run_consumer.py` | `QUEUE_NAMES` (partitioned) | Buffers chunks in DuckDB, on sentinel: retrieves, embeds, upserts to Qdrant, archives to Parquet |
 | **FastAPI** | `apimain.py` | HTTP :8000 | REST API for chat queries, status, and health checks |
+
+The **Gatekeeper** worker uses the supervisor LLM (configured via `SUPERVISOR_LLM_PATH`) for normalization. The **RAG chat** uses a separate LLM (configured via `LLM_PATH`). In many deployments these run on the same GPU host but are distinct conceptual roles — normalization during ingestion vs. inference during chat.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,178 @@
+# Quick Start Guide
+
+**[< README](../README.md) | [Architecture](overview.md) | [Deep Dive](deep-dive.md) | [Operations](operations.md)**
+
+---
+
+## Prerequisites
+
+System dependencies (baked into the Docker image):
+- `ffmpeg` — audio extraction for WhisperX
+- `poppler-utils` — PDF page rendering
+- `libgl1` / `libglib2.0-0` — OpenCV/vision processing
+
+**Docker v2.20+** — for the containerized worker stack
+**Node.js v22.12.0+** — for frontend development
+
+---
+
+## Service Model
+
+Every AI workload runs as an HTTP(S) service on a dedicated LAN host. Workers connect to these services as remote API clients. The system auto-detects local-vs-remote from the URL scheme:
+
+- **Remote URL** (`http(s)://...`): Workers use OpenAI-compatible HTTP clients. No model loaded locally. The remote server handles its own GPU, context, and batching settings.
+- **Local path** (`/home/user/models/...`): The model is loaded directly in the worker container via llama-cpp or HuggingFace.
+
+You can mix and match — some services remote, some local.
+
+---
+
+## Mandatory Environment Variables
+
+These four must be set. Each accepts a remote URL or a local path.
+
+| Env Var | Service Role | Example (Remote) | Example (Local) |
+|---------|-------------|-----------------|-----------------|
+| `DEFAULT_DOC_INGEST_ROOT` | Local directory for all lifecycle stages (staging, preprocessing, ingestion, consuming, success, failed) | `export DEFAULT_DOC_INGEST_ROOT=/home/user/rag-docs` | same |
+| `LLM_PATH` | **Chat LLM** — the inference model used for RAG queries. Runs on a GPU host via llama-server or any OpenAI-compatible API. | `http://<llm-host>:11434/v1/chat/completions` | `/models/Phi-4-mini-instruct-Q6_K.gguf` |
+| `SUPERVISOR_LLM_PATH` | **Gatekeeper LLM** — the normalization model used by the gatekeeper worker to convert raw extracted text into clean Markdown during ingestion. Often the same host as the chat LLM. | `http://<llm-host>:11434/v1/chat/completions` | `/models/Qwen2.5-1.5B-Instruct-GGUF` |
+| `EMBEDDING_MODEL_PATH` | **Embedding model** — vectorizes chunks during ingestion and queries during chat. | `http://<embedding-host>:11434/v1/embeddings` | `/models/e5-large-v2` |
+
+---
+
+## Optional Service Endpoints
+
+The remaining services have defaults and only need configuration when using remote hosts.
+
+| Env Var | Service Role | Default | Example (Remote) |
+|---------|-------------|---------|-----------------|
+| `VECTOR_DB_URL` | **Vector DB** — Qdrant (gRPC on port 6334, REST on 6333) or Chroma. Overrides `VECTOR_DB_HOST` and `VECTOR_DB_PORT`. | `vector-db` (Docker service name) | `http://<vector-db-host>:6334` |
+| `VECTOR_DB_PROFILE` | Vector database selection | `qdrant` | `qdrant` or `chroma` |
+| `VECTOR_DB_USE_GRPC` | Use gRPC for Qdrant | `true` | `true` or `false` |
+| `WHISPER_MODEL_PATH` | **WhisperX** — transcribes MP3, MP4, WAV, MOV, MKV files during ingestion. Set to a remote URL or local model directory. | `NOT_SET` | `http://<whisper-host>:1145/inference` |
+| `OCR_PATH` | **OCR** — docling-serve for PDF OCR fallback when pdfplumber cannot extract text. | `LOCAL` | `http://<ocr-host>:5001/v1/convert/file` |
+| `PDF_FORCE_OCR` | Skip pdfplumber and use OCR for all PDF pages | `false` | `true` |
+| `LLAMA_USE_GPU` | Enable GPU acceleration for locally-loaded models | `true` | `true` or `false` |
+
+---
+
+## Worker Stack
+
+The ingestion workers run on the coordinator host. They handle document lifecycle state transitions and coordinate with the remote services.
+
+| Worker | Entry Point | Role |
+|--------|------------|------|
+| **Gatekeeper** | `run_gatekeeper.py` | Claims files from staging, extracts raw text via content handlers, normalizes to Markdown via the supervisor LLM, writes `.md` output |
+| **Producer** | `run_producer.py` | Claims normalized Markdown, splits into chunks with `[DOC_XXXX]` IDs, enqueues to Redis consumer queues |
+| **Consumer** | `run_consumer.py` | Buffers chunks in DuckDB, embeds via the embedding service, batch-upserts to Qdrant, archives to Parquet |
+| **OCR Worker** | `run_ocr_worker.py` | Processes image-based PDF pages via docling-serve |
+| **WhisperX Worker** | `run_whisperx_worker.py` | Transcribes audio/video files |
+
+---
+
+## Distributed Deployment
+
+Every heavy service runs on a dedicated host or container. The worker stack runs on the coordinator.
+
+```
++-------------------+   +-------------------+   +-------------------+
+|    <llm-host>     |   |  <embedding-host> |   |  <vector-db-host> |
+|    (GPU host)     |   |                   |   |                   |
+|                   |   |  embedding model  |   |  Qdrant           |
+| chat LLM +        |   |  :11434/v1        |   |  gRPC:6334        |
+| gatekeeper LLM    |   |                   |   |  REST:6333        |
+| :11434/v1         |   |                   |   |                   |
++-------------------+   +-------------------+   +-------------------+
+
++-------------------+   +-------------------+
+|   <whisper-host>  |   |    <ocr-host>     |
+|                   |   |                   |
+|  WhisperX         |   |  docling-serve    |
+|  :1145/inference  |   |  :5001/v1         |
++-------------------+   +-------------------+
+
+              +-------------------------------+
+              |       Coordinator Host        |
+              |                               |
+              |  gatekeeper + producer +      |
+              |  consumer + OCR worker +      |
+              |  WhisperX worker              |
+              +-------------------------------+
+```
+
+The coordinator connects to all services over HTTP. Each remote host can be optimized for its specific workload (GPU for LLM, CPU+RAM for WhisperX, NVMe for Qdrant).
+
+---
+
+## Air-Gapped / Offline by Design
+
+- `HF_HUB_OFFLINE=1` is baked into all Docker images — HuggingFace libraries never phone home
+- Docling OCR models are cached during Docker build-time warmup — no runtime downloads
+- All service URLs are LAN addresses only
+- Worker images are self-contained; no external API calls during ingestion or query
+- The entire system operates on a private network with no internet access required
+
+---
+
+## Hardware Profile
+
+Reference specs for a coordinator host running the worker stack:
+
+| Component | Specification |
+|-----------|--------------|
+| CPU | Intel i9-14900KF (24-core) — or any modern multi-core CPU |
+| GPU | NVIDIA RTX 4070 12GB — or eGPU via OCuLink dock |
+| RAM | 32 GB DDR5 |
+| OS | Ubuntu 22.04+ / Python 3.11 |
+| Storage | NVMe SSD recommended for document throughput |
+
+Performance on this setup: 10-15 PDFs/min (mixed quality), ~400ms query latency (p50), Qdrant tested with 10K+ chunks at sub-second retrieval.
+
+---
+
+## Local-Only Deployment
+
+To run everything locally without remote services, use local model paths instead of URLs:
+
+```bash
+export DEFAULT_DOC_INGEST_ROOT=/home/user/rag-docs
+export LLM_PATH=/home/user/models/Phi-4-mini-instruct-Q6_K.gguf
+export SUPERVISOR_LLM_PATH=/home/user/models/Qwen2.5-1.5B-Instruct-GGUF
+export EMBEDDING_MODEL_PATH=/home/user/models/e5-large-v2
+export WHISPER_MODEL_PATH=/home/user/models/whisper
+export OCR_PATH=LOCAL
+export VECTOR_DB_PROFILE=qdrant
+export LLAMA_USE_GPU=true
+```
+
+---
+
+## Launch
+
+```bash
+./doc-ingest-chat/run-compose.sh --build
+```
+
+The stack starts: Redis → Gatekeeper → Producer → OCR Worker → WhisperX Worker → Consumer → FastAPI backend.
+
+Docker Compose supports profiles:
+- `--profile gpu` (default) — NVIDIA GPU acceleration
+- `--profile cpu` — CPU-only mode
+- `--profile qdrant` or `--profile chroma` — vector database selection
+
+---
+
+## Usage
+
+1. Drop files into `$DEFAULT_DOC_INGEST_ROOT/staging/`. Supported formats: `.pdf`, `.html`, `.htm`, `.txt`, `.md`, `.mp3`, `.wav`, `.m4a`, `.aac`, `.flac`, `.mp4`, `.mov`, `.mkv`
+
+2. Monitor progress:
+
+```bash
+docker logs -f gatekeeper_worker   # normalization progress
+docker logs -f consumer_worker     # embedding and Qdrant upsert
+```
+
+3. Open [http://localhost:4321](http://localhost:4321) to chat with your documents.
+
+Ingestion and querying are fully concurrent. You can start chatting with already-processed documents immediately while the system continues ingesting the rest.


### PR DESCRIPTION
## Summary

Reorganized documentation to make the repository more approachable for new visitors.

### Changes
- **`README.md`**: Rewrote as a clean landing page (214 to 96 lines). Added table of contents and prominent documentation navigation section. Removed all LAN-specific hostnames and IP addresses. Uses generic service-oriented placeholders (`<llm-host>`, `<embedding-host>`, `<vector-db-host>`, `<whisper-host>`, `<ocr-host>`).
- **`docs/quickstart.md`** (new): Full environment configuration with service role tables, distributed deployment diagram, hardware profile, and local-only alternatives. Moved from README to keep the landing page focused.
- **`docs/overview.md`**: Moved nav links to top of file. Added clarification on gatekeeper/supervisor LLM naming.
- **`docs/deep-dive.md`**: Moved nav links to top of file.
- **`docs/operations.md`**: Moved nav links to top of file. Replaced `<qdrant-host>` with `<vector-db-host>`.
- **`docs/edge-agent.md`**: Moved nav links to top of file.
- **`CHANGELOG.md`**: Added entry documenting the reorganization.