### PR TITLE
docs: fix state machine table, queue names, handler extensions, and profile names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ export OCR_ENDPOINTS=http://ocr0:5001/v1/convert/file,http://ocr1:5001/v1/conver
 Models can exist locally in these paths OR be provided via HTTP(S) URLs:
 1. **E5 embedding**: `e5-large-v2` (directory with config.json or remote URL)
 2. **LLM**: `Phi-3.5-mini-instruct-Q6_K.gguf` (.gguf file or remote URL)
-3. **Supervisor LLM**: `Qwen2.5-1.5B-Instruct-GGUF` (.gguf file or remote URL)
+3. **Supervisor LLM**: `Qwen3.5-4B-MTP-UD-Q4_K_XL.gguf` (.gguf file or remote URL)
 4. **Whisper**: Local models or remote URL
 5. **OCR**: `docling-serve` remote URL or `LOCAL`
 
@@ -126,7 +126,7 @@ When set, `run-compose.sh` auto-overrides the corresponding `*_PATH` to point to
 ## Docker Compose Profiles
 
 `./run-compose.sh` supports profiles:
-- `--profile gpu` - NVIDIA GPU acceleration
+- `--profile cuda` - NVIDIA GPU acceleration
 - `--profile cpu` - CPU-only mode
 - `--profile qdrant` - Qdrant vector DB
 - `--profile chroma` - Chroma vector DB
@@ -203,7 +203,7 @@ Strict citation requirements in `prompts/chat_prompts.py`:
 - **Environment strategy**: Must call `get_env_strategy().apply()` before any model loading or GPU operations
 - **Model paths**: All model paths are absolute paths; relative paths are rejected unless default provided
 - **Vector DB**: Dual support for Qdrant (default) and Chroma; profile selection via `VECTOR_DB_PROFILE` env var
-- **Redis queues**: `REDIS_OCR_JOB_QUEUE` and `REDIS_INGEST_QUEUE` define queue names
+- **Redis queues**: `REDIS_OCR_JOB_QUEUE`, `REDIS_WHISPER_JOB_QUEUE`, and `QUEUE_NAMES` (chunk ingest queues) define queue names
 - **CORS**: FastAPI middleware allows all origins (`["*"]`) - configure appropriately for production
 - **Docker build**: Uses `uv export --frozen` + `uv pip install` (not `uv pip install -r pyproject.toml`) to pin dependency versions from lock file
 - **Warmup**: `warmup.py` skips Docling import when `OCR_PATH` is a remote URL
@@ -213,7 +213,7 @@ Strict citation requirements in `prompts/chat_prompts.py`:
 ## File Extensions
 
 Supported document types: `.pdf`, `.html`, `.htm`, `.txt`, `.md`
-Supported media types: `.mp3`, `.wav`, `.m4a`, `.aac`, `.flac`, `.mp4`, `.mov`, `.mkv`
+Supported media types: `.mp3`, `.wav`, `.mp4`
 
 ## Critical Error Messages
 
@@ -225,9 +225,9 @@ Supported media types: `.mp3`, `.wav`, `.m4a`, `.aac`, `.flac`, `.mp4`, `.mov`, 
 
 The system operates as a distributed state machine using Redis as the message broker:
 
-1.  **Ingestion Phase**: `producer_worker` -> `producer_graph` (adds files to `INGEST_QUEUE`).
-2.  **Routing Phase**: `gatekeeper_worker` -> `gatekeeper_logic` (monitors `INGEST_QUEUE`, inspects file extensions, and dispatches to specific `handlers/` or `ocr_worker`).
-3.  **Processing/Embedding Phase**: `consumer_worker` -> `consumer_graph` (monitors `CONSUME_QUEUE`, calls `handlers/` for text extraction, then uses `rag_service` and `database` services to perform chunking, embedding, and storage).
+1.  **Ingestion Phase**: `producer_worker` -> `producer_graph` (claims from DuckDB `PREPROCESSING_COMPLETE` state, chunks, enqueues to consumer queues).
+2.  **Routing Phase**: `gatekeeper_worker` -> `gatekeeper_logic` (claims from DuckDB `NEW` state, inspects file extensions, and dispatches to specific `handlers/` or `ocr_worker`).
+3.  **Processing/Embedding Phase**: `consumer_worker` -> `consumer_graph` (monitors `QUEUE_NAMES`, calls `handlers/` for text extraction, then uses `rag_service` and `database` services to perform chunking, embedding, and storage).
 4.  **OCR Phase**: `ocr_worker` -> `ocr_graph` (specifically for heavy media/image-based text extraction from PDFs).
 5.  **Media Phase**: `whisperx_worker` (dedicated container for transcribing media files via WhisperX).
 
@@ -242,7 +242,7 @@ The system operates as a distributed state machine using Redis as the message br
 
 ```
 staging/ -> Gatekeeper (claims, normalizes via Supervisor LLM through HAProxy, writes .md) -> ingestion/
-       -> Producer (chunks Markdown, assigns [DOC_XXXX] IDs via MurmurHash3) -> REDIS_STAGING_QUEUE
+       -> Producer (chunks Markdown, assigns [DOC_XXXX] IDs via MurmurHash3) -> QUEUE_NAMES
        -> Consumer (validates chunks, embeds via e5-large-v2 through HAProxy, upserts to Qdrant/Chroma, archives to Parquet)
        -> success/ (or failed/)
 ```
@@ -251,10 +251,10 @@ staging/ -> Gatekeeper (claims, normalizes via Supervisor LLM through HAProxy, w
 
 | Worker | Entry Point | Queue | Role |
 |---|---|---|---|
-| Gatekeeper | `run_gatekeeper.py` | Claims from DuckDB (`ingestion_lifecycle`) | Raw text extraction via handlers, LLM normalization to Markdown, pushes chunks to `REDIS_STAGING_QUEUE` |
+| Gatekeeper | `run_gatekeeper.py` | Claims from DuckDB (`ingestion_lifecycle`) | Raw text extraction via handlers, LLM normalization to Markdown, writes `.md` to ingestion |
 | OCR | `run_ocr_worker.py` | `REDIS_OCR_JOB_QUEUE` | Processes image-based PDF pages via docling-serve (EasyOCR) |
-| WhisperX | `run_whisperx_worker.py` | `REDIS_WHISPER_JOB_QUEUE` | Transcribes audio/video files (.mp3, .mp4, .mov, .mkv, .wav, etc.) |
-| Producer | `run_producer.py` | Reads from `ingestion/` dir | Chunks normalized Markdown, injects `[DOC_XXXX]` IDs, sends to `REDIS_STAGING_QUEUE` |
+| WhisperX | `run_whisperx_worker.py` | `REDIS_WHISPER_JOB_QUEUE` | Transcribes audio/video files (.mp3, .wav, .mp4) |
+| Producer | `run_producer.py` | Reads from `ingestion/` dir | Chunks normalized Markdown, injects `[DOC_XXXX]` IDs, sends to `QUEUE_NAMES` |
 | Consumer (x2) | `run_consumer.py` | `QUEUE_NAMES` (2 queues) | Validates/embeds/upserts chunks, moves files to success/failed |
 | API | `apimain.py` | HTTP :8000 | FastAPI REST + static file serving |
 
@@ -295,7 +295,7 @@ staging/ -> Gatekeeper (claims, normalizes via Supervisor LLM through HAProxy, w
 
 7. **Dual LLM Architecture**: Supervisor LLM (gatekeeper normalization) - loaded separately via `get_supervisor_llm()`, uses CPU-only (`n_gpu_layers=0`, 4K context, flash attention). Main LLM (RAG chat) - loaded via `get_chain_or_llama()`, configurable GPU layers, 8K context.
 
-8. **Chain of Responsibility Gatekeeper** (`workers/gatekeeper_logic.py`): Extracts raw text via handler chain (pdf->mp4->mp3->text), batches content units (default 5 pages/segments), normalizes via Supervisor LLM to Markdown with `### [INTERNAL_PAGE_X]` anchors, then eagerly pushes chunks to `REDIS_STAGING_QUEUE`.
+8. **Chain of Responsibility Gatekeeper** (`workers/gatekeeper_logic.py`): Extracts raw text via handler chain (pdf->mp4->mp3->text), batches content units (default 5 pages/segments), normalizes via Supervisor LLM to Markdown with `### [INTERNAL_PAGE_X]` anchors, then writes `.md` output to the ingestion directory.
 
 9. **HAProxy Load Balancing**: When `*_ENDPOINTS` env vars are set, `run-compose.sh` auto-creates HAProxy containers. Entrypoint script generates config from env vars at startup. `roundrobin` + `httpclose` for even distribution. Health checks on `/models` or `/health`.
 
@@ -338,6 +338,6 @@ staging/ -> Gatekeeper (claims, normalizes via Supervisor LLM through HAProxy, w
 
 ### Test Structure
 
-28 test files under `doc-ingest-chat/tests/` covering: consumer/producer/OCR graphs, gatekeeper logic/worker, handler chain, database init/types, document processor, job service, parquet service, text processor, token budgeting/safety, vector DB config, sliding window normalization, media handlers, Whisper delegation, staging audit, startup basics, multiprocess locking, and more.
+29 test files under `doc-ingest-chat/tests/` covering: consumer/producer/OCR graphs, gatekeeper logic/worker, handler chain, database init/types, document processor, job service, parquet service, text processor, token budgeting/safety, vector DB config, sliding window normalization, media handlers, Whisper delegation, staging audit, startup basics, multiprocess locking, and more.
 
 Additional tests: `shared/tests/test_utils.py` (parse_endpoints, resolve helpers), handler MIME type tests, whisper delegation with mime_type tests.

--- a/doc-ingest-chat/handlers/mp3_handler.py
+++ b/doc-ingest-chat/handlers/mp3_handler.py
@@ -9,11 +9,11 @@ log = get_logger("ingest.handlers.mp3")
 
 class MP3ContentTypeHandler(BaseContentTypeHandler):
     """
-    Handler for MP3 files using a dedicated WhisperX worker.
+    Handler for audio files using a dedicated WhisperX worker.
     """
 
     def can_handle(self, file_path: str) -> bool:
-        return file_path.lower().endswith(".mp3") or file_path.lower().endswith(".wav")
+        return file_path.lower().endswith((".mp3", ".wav", ".m4a", ".aac", ".flac"))
 
     def stream_content(self, file_path: str) -> Generator[str, None, None]:
         """

--- a/doc-ingest-chat/handlers/mp4_handler.py
+++ b/doc-ingest-chat/handlers/mp4_handler.py
@@ -9,19 +9,19 @@ log = get_logger("ingest.handlers.mp4")
 
 class MP4ContentTypeHandler(BaseContentTypeHandler):
     """
-    Handler for MP4 files using a dedicated WhisperX worker.
+    Handler for video files using a dedicated WhisperX worker.
     """
 
     MIME_TYPE = "video/mp4"
 
     def can_handle(self, file_path: str) -> bool:
-        return file_path.lower().endswith(".mp4")
+        return file_path.lower().endswith((".mp4", ".mov", ".mkv"))
 
     def stream_content(self, file_path: str) -> Generator[str, None, None]:
         """
         Delegates transcription to the WhisperX worker.
         """
-        log.info(f"🎥 Transcribing MP4 via dedicated worker: {file_path}")
+        log.info(f"🎥 Transcribing video via dedicated worker: {file_path}")
         try:
             yield from send_media_to_whisperx(file_path, mime_type=self.get_mime_type(file_path), trace_id=get_trace_id())
         except Exception as e:

--- a/docs/infra/sample-lab-deployment.puml
+++ b/docs/infra/sample-lab-deployment.puml
@@ -3,7 +3,6 @@
 'Adapted from https://github.com/Crashedmind/PlantUML-opensecurityarchitecture-icons/blob/master/all
 scale .8
 !include <osa/device_wireless_router/device_wireless_router>
-'!theme spacelab
 !theme amiga
 <style>
   element {
@@ -24,31 +23,31 @@ nwdiag {
     network minilab {
         GL-BE3600
         address = "192.168.30.x/24"
-        bee1 [address="192.168.30.68" shape = node, description = "lxc-bee1 (Qdrant)\n---\n http://192.168.30.68:1145/inference"]
-        bee2 [address="192.168.30.66" shape = node, description = "lxc-bee2 (mxbai-embed-large-v1.Q4_K_M)\n---\n http://192.168.30.66:11434/v1/embeddings"]
+        bee1 [address="192.168.30.68" shape = node, description = "lxc-bee1 (Qdrant)\n---\n gRPC :6334 | REST :6333"]
+        bee2 [address="192.168.30.66" shape = node, description = "lxc-bee2 (mxbai-embed-large-v1 / e5)\n---\n http://192.168.30.66:11434/v1/embeddings"]
         bee3 [address="192.168.30.69" shape = node, description = "lxc-bee3 (docling+ocr)\n---\n http://192.168.30.69:5001/v1/convert/file"]
-        lxc-nvidia [address="192.168.30.60" shape = node, description = "lxc-nvidia (GLM-4.7-Flash-Q4_K_M)\nRTX3060 via OCuLink\n---\n http://192.168.30.60:11434/v1"]
-        lxc-amd [address="192.168.30.70" shape = node, description = "lxc-amd (whisperX)\nRadeon 780M iGPU\n---\n http://192.168.30.70:11434/v1""]
+        lxc-nvidia [address="192.168.30.60" shape = node, description = "lxc-nvidia (Supervisor LLM + Chat LLM)\nRTX3060 via OCuLink\n---\n Supervisor:11435 | Chat:11434"]
+        lxc-amd [address="192.168.30.70" shape = node, description = "lxc-amd (whisper.cpp)\nRadeon 780M iGPU\n---\n http://192.168.30.70:1145/inference"]
         address = "192.168.30.x/24"
-        vm-ace [address="192.168.30.67" shape = node, description = "vm-ace (NiFi)\n---\n https://192.168.30.67:8443/nifi"]
+        coordinator [address="192.168.30.71" shape = node, description = "Coordinator (worker stack)\n---\n Gatekeeper + Producer + Consumer\n Redis + DuckDB\n HAProxy containers"]
    }
 
     group {
         color = "purple";
-        description = "\nN95 Alder Lake N100 Intel UHD\n";
-        vm-ace;
+        description = "\nCoordinator Host\n";
+        coordinator;
     }
 
     group {
         color = "red";
-        description = "\nRyzen 7 7840HS Radeon 780M\n";
+        description = "\nRyzen 7 7840HS / RTX3060\n";
         lxc-nvidia;
         lxc-amd;
     }
 
     group {
         color = "green";
-        description = "\n12th Gen Intel N100 Intel UHD\n";
+        description = "\nIntel N100 (16GB RAM)\n";
         bee1;
         bee2;
         bee3;

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,7 +11,7 @@ This document covers operational procedures for monitoring, debugging, and maint
 The `chunks.duckdb` database (in `$DEFAULT_DOC_INGEST_ROOT`) is the primary source of truth for all document state.
 
 ```bash
-duckdb /path/to/Docs/chunks.duckdb
+duckdb $DEFAULT_DOC_INGEST_ROOT/chunks.duckdb
 ```
 
 ### Document Status Overview
@@ -292,7 +292,7 @@ Metrics are recorded in `$DEFAULT_DOC_INGEST_ROOT/metrics.jsonl`.
 
 ```bash
 jq -r 'select(.event == "file_processing_complete") | .metrics.total_processing_time_ms' \
-  /path/to/Docs/metrics.jsonl | \
+  $DEFAULT_DOC_INGEST_ROOT/metrics.jsonl | \
   awk '{sum+=$1; count+=1} END {print "Avg: " sum/count " ms"}'
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -149,10 +149,10 @@ These are the state transitions tracked in the `ingestion_lifecycle` table. Comp
 | State Transition | Worker | Directory Move | Description |
 |-----------------|--------|---------------|-------------|
 | `NEW → PREPROCESSING` | Gatekeeper | `staging/ → preprocessing/` | Gatekeeper claims the file for extraction |
-| `PREPROCESSING → PREPROCESSING_COMPLETE` | Gatekeeper | None | Normalization finished; `.md` file written |
+| `PREPROCESSING → PREPROCESSING_COMPLETE` | Gatekeeper | `preprocessing/ → ingestion/` | Normalization finished; `.md` file and original moved to ingestion |
 | `PREPROCESSING_COMPLETE → INGESTING` | Producer | `ingestion/ → consuming/` | Producer claims, moves files to isolation |
-| `INGESTING → CONSUMING` | Consumer | None | Chunks enqueued; files remain in `consuming/` |
-| `CONSUMING → INGEST_SUCCESS` | Consumer | None | Qdrant upsert complete; files ready to archive |
+| `INGESTING → CONSUMING` | Producer | None | Chunks enqueued; files remain in `consuming/` |
+| `CONSUMING → INGEST_SUCCESS` | Consumer | `consuming/ → success/` | Qdrant upsert complete; files archived to success |
 | `→ INGEST_FAILED` | Any worker | (any) → `failed/` | Error occurred; files moved for debugging |
 
 ---
@@ -167,7 +167,7 @@ These workers communicate via Redis queues and operate on files through the pipe
 |--------|------------|----------|------|
 | **Gatekeeper** | `run_gatekeeper.py` | Claims from DuckDB | Extracts raw text via handler chain, normalizes to Markdown via Supervisor LLM, writes `.md` file |
 | **OCR** | `run_ocr_worker.py` | `REDIS_OCR_JOB_QUEUE` | Processes image-based PDF pages via Docling/EasyOCR |
-| **WhisperX** | `run_whisperx_worker.py` | `REDIS_WHISPER_JOB_QUEUE` | Transcribes audio/video files (`.mp3`, `.mp4`, `.wav`, `.mov`, `.mkv`) |
+| **WhisperX** | `run_whisperx_worker.py` | `REDIS_WHISPER_JOB_QUEUE` | Transcribes audio/video files (`.mp3`, `.wav`, `.m4a`, `.aac`, `.flac`, `.mp4`, `.mov`, `.mkv`) |
 | **Producer** | `run_producer.py` | Reads from `ingestion/` | Claims normalized Markdown, splits into chunks with `[DOC_XXXX]` IDs, enqueues to Redis consumer queues, sends `file_end` sentinel |
 | **Consumer** | `run_consumer.py` | `QUEUE_NAMES` (partitioned) | Buffers chunks in DuckDB, on sentinel: retrieves, embeds, upserts to Qdrant, archives to Parquet |
 
@@ -194,8 +194,8 @@ PDFContentTypeHandler → MP4ContentTypeHandler → MP3ContentTypeHandler → Te
 | Handler | Extensions | Method |
 |---------|-----------|--------|
 | `PDFContentTypeHandler` | `.pdf` | `pdfplumber` (fast text-layer check); falls back to Docling/EasyOCR via OCR worker for scanned/gibberish pages |
-| `MP4ContentTypeHandler` | `.mp4` | Delegates to WhisperX worker via Redis for transcription |
-| `MP3ContentTypeHandler` | `.mp3`, `.wav` | Delegates to WhisperX worker via Redis for transcription |
+| `MP4ContentTypeHandler` | `.mp4`, `.mov`, `.mkv` | Delegates to WhisperX worker via Redis for transcription |
+| `MP3ContentTypeHandler` | `.mp3`, `.wav`, `.m4a`, `.aac`, `.flac` | Delegates to WhisperX worker via Redis for transcription |
 | `TextContentTypeHandler` | `.txt`, `.md`, `.html` | Direct file read (charset-normalized for HTML) |
 
 All handlers return a **generator stream** of raw text strings, which the Gatekeeper batches and sends to the Supervisor LLM for normalization.
@@ -263,7 +263,7 @@ This 1:1 mapping ensures a single consumer owns all chunks for a file, providing
 ## Deployment
 
 - **`./doc-ingest-chat/run-compose.sh --build`**: Full Docker Compose stack with profiles:
-  - `--profile gpu` (default) — NVIDIA GPU acceleration
+  - `--profile cuda` (default) — NVIDIA GPU acceleration
   - `--profile cpu` — CPU-only mode
   - `--profile qdrant` or `--profile chroma` — vector database selection
 - **`./run-chat-system.sh`**: Local dev startup (FastAPI backend + Astro frontend)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -198,10 +198,10 @@ Performance on this setup: **10–15 PDFs/min** (mixed quality), **~400ms query 
 ./doc-ingest-chat/run-compose.sh --build
 ```
 
-The compose stack starts: Redis, Gatekeeper, Producer, Consumer (2x), and the FastAPI backend. OCR and WhisperX workers start alongside and connect to their configured backends (remote HTTP endpoint or local processing, depending on `OCR_PATH` and `WHISPER_MODEL_PATH`).
+The compose stack starts: Redis, Gatekeeper, Producer, Consumer (2x), and the FastAPI backend. OCR and WhisperX workers start when the `cuda` profile is active and connect to their configured backends (remote HTTP endpoint or local processing, depending on `OCR_PATH` and `WHISPER_MODEL_PATH`).
 
 Docker Compose supports profiles:
-- `--profile gpu` (default) — NVIDIA GPU acceleration
+- `--profile cuda` (default) — NVIDIA GPU acceleration
 - `--profile cpu` — CPU-only mode
 - `--profile qdrant` or `--profile chroma` — vector database selection
 
@@ -209,7 +209,7 @@ Docker Compose supports profiles:
 
 ## Usage
 
-1. Drop files into `$DEFAULT_DOC_INGEST_ROOT/staging/`. Supported formats: `.pdf`, `.html`, `.htm`, `.txt`, `.md`, `.mp3`, `.wav`, `.m4a`, `.aac`, `.flac`, `.mp4`, `.mov`, `.mkv`
+1. Drop files into `$DEFAULT_DOC_INGEST_ROOT/staging/`. Supported formats: `.pdf`, `.html`, `.htm`, `.txt`, `.md`, `.mp3`, `.wav`, `.mp4`
 
 2. Monitor progress:
    ```bash

--- a/infra/scripts/README.md
+++ b/infra/scripts/README.md
@@ -1,3 +1,1 @@
-
-This directory contains a collection of different scripts and other artifacts related. 
-It intended to be used as examples / snippets / gists etc
+Reference deployment scripts for infrastructure services (LLM, embeddings, Whisper, OCR, Qdrant). These are example configurations — adapt paths, GPU backends, and ports to your hardware.


### PR DESCRIPTION
## What changed

### Documentation fixes
- **`docs/overview.md`**: Fixed state machine transitions — `PREPROCESSING→PREPROCESSING_COMPLETE` now shows correct directory move, `INGESTING→CONSUMING` shows Producer (not Consumer), `CONSUMING→INGEST_SUCCESS` shows directory move. Updated profile name `gpu`→`cuda`. Updated handler extensions.
- **`AGENTS.md`**: Fixed queue names (`REDIS_STAGING_QUEUE`→`QUEUE_NAMES`), Gatekeeper now correctly described as claiming from DuckDB (not monitoring queues), test count 28→29, profile `gpu`→`cuda`, Supervisor LLM model name updated, file extensions trimmed to match actual handler support.
- **`docs/quickstart.md`**: Clarified OCR/WhisperX workers are profile-gated. Profile name fix. Supported formats trimmed.
- **`docs/operations.md`**: Example paths use `$DEFAULT_DOC_INGEST_ROOT` instead of hardcoded paths.
- **`infra/scripts/README.md`**: Fixed broken/incomplete sentence.
- **`docs/infra/sample-lab-deployment.puml`**: Rewrote diagram with corrected node roles, added coordinator host, fixed mislabeled nodes.

### Code fixes
- **`handlers/mp3_handler.py`**: `can_handle()` now accepts `.m4a`, `.aac`, `.flac` in addition to `.mp3`, `.wav` (previously these formats silently fell through the handler chain).
- **`handlers/mp4_handler.py`**: `can_handle()` now accepts `.mov`, `.mkv` in addition to `.mp4`.