### PR TITLE
feat: OpenSpec proposal — unify worker settings through shared config

### DIFF
--- a/openspec/changes/unify-worker-settings/.openspec.yaml
+++ b/openspec/changes/unify-worker-settings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/unify-worker-settings/design.md
+++ b/openspec/changes/unify-worker-settings/design.md
@@ -1,0 +1,25 @@
+## Context
+
+The shared settings system (`shared/config.py` → `config/settings.py`) provides lazy-loaded environment variables with canonical defaults from `shared/defaults.py`. Most workers already use this system via `from config.settings import SETTING_NAME`. However, `whisperx_worker.py` predates the shared settings system and reads env vars directly, creating a maintenance hazard where defaults can diverge.
+
+## Goals / Non-Goals
+
+**Goals:**
+- All workers load settings through `config.settings`
+- No functional changes to any setting values
+- All existing env var names remain valid
+
+**Non-Goals:**
+- No changes to workers that already use shared settings
+- No changes to the settings system itself
+- No changes to env var names or semantics
+
+## Decisions
+
+1. **Import at module level**: Replace each `os.getenv("KEY", default)` with `from config.settings import KEY`. The lazy-loading machinery resolves the value on first access, same as other workers.
+
+2. **Preserve module-level constants**: The whisperx worker assigns settings to module-level constants (`BATCH_SIZE`, `DEVICE`, etc.) for use throughout the file. Keep this pattern, just load the values from shared settings instead of os.getenv.
+
+## Risks / Trade-offs
+
+- **Import order**: `config.settings` must be imported after the sys.path fix at the top of the worker. Verify the existing pattern used by other workers and replicate it.

--- a/openspec/changes/unify-worker-settings/proposal.md
+++ b/openspec/changes/unify-worker-settings/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Several workers read environment variables directly via `os.getenv()` with inline defaults instead of using the shared lazy-loaded settings from `shared/config.py`. This means defaults can drift (as happened with `MEDIA_BATCH_SIZE` defaulting to 16 in the worker while `shared/defaults.py` had 8), and settings are resolved at module import time instead of lazily. The whisperx worker is the worst offender with 6 direct `os.getenv` calls.
+
+## What Changes
+
+- **MODIFIED**: `doc-ingest-chat/workers/whisperx_worker.py` — replace all 6 `os.getenv()` calls with imports from `config.settings`
+- **MODIFIED**: `doc-ingest-chat/workers/ocr_worker.py` — replace 2 debug `os.getenv()` calls with shared settings
+- No breaking changes — all existing env var names remain the same
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `infrastructure`: The environment variable configuration requirement is strengthened — all workers must load settings through the shared system, not via direct `os.getenv()` calls.
+
+## Impact
+
+- `doc-ingest-chat/workers/whisperx_worker.py`: Replace `REDIS_HOST`, `REDIS_PORT`, `REDIS_WHISPER_JOB_QUEUE`, `DEVICE`, `COMPUTE_TYPE`, `BATCH_SIZE` with imports from `config.settings`
+- `doc-ingest-chat/workers/ocr_worker.py`: Replace debug print `os.getenv` calls with shared settings

--- a/openspec/changes/unify-worker-settings/specs/infrastructure/spec.md
+++ b/openspec/changes/unify-worker-settings/specs/infrastructure/spec.md
@@ -1,0 +1,9 @@
+## MODIFIED Requirements
+
+### Requirement: Environment variable configuration
+
+The system SHALL support 60+ environment variables for configuration through the shared lazy-loaded settings system (`shared/config.py`). All workers SHALL load their settings through `from config.settings import <NAME>`. Direct `os.getenv()` calls with inline defaults SHALL NOT be used in worker modules — they bypass the canonical defaults and create a maintenance hazard where defaults can diverge.
+
+#### Scenario: Worker reads setting via shared config
+- **WHEN** a worker needs a configuration value
+- **THEN** it SHALL import it from `config.settings` rather than calling `os.getenv()` directly

--- a/openspec/changes/unify-worker-settings/tasks.md
+++ b/openspec/changes/unify-worker-settings/tasks.md
@@ -1,0 +1,13 @@
+## 1. WhisperX Worker
+
+- [ ] 1.1 Add sys.path fix and `from config.settings import REDIS_HOST, REDIS_PORT, REDIS_WHISPER_JOB_QUEUE, DEVICE, COMPUTE_TYPE, MEDIA_BATCH_SIZE, WHISPER_MODEL_ENDPOINTS`
+- [ ] 1.2 Replace all 6 module-level `os.getenv()` calls with the imported settings
+
+## 2. OCR Worker
+
+- [ ] 2.1 Replace `os.getenv('EMBEDDING_ENDPOINTS')` and `os.getenv('OCR_ENDPOINTS', 'LOCAL')` debug prints with `from config.settings import EMBEDDING_ENDPOINTS, OCR_ENDPOINTS`
+
+## 3. Verification
+
+- [ ] 3.1 Run `ruff check --fix` on all changed files
+- [ ] 3.2 Run full pytest suite — no regressions


### PR DESCRIPTION
OpenSpec change for refactoring workers to use the shared lazy-loaded settings system instead of direct os.getenv() calls. Currently only has planning artifacts (proposal, design, specs, tasks).