### PR TITLE
feat: unify worker settings through shared config, add embedding progress logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **Unified worker settings**: All workers now load configuration through `config.settings` instead of direct `os.getenv()` calls. Added missing `API_BASE_URL`, `HF_HOME`, and `HF_HUB_OFFLINE` settings to shared config. Removed direct `shared.env_names` imports from `llama_strategy.py`. Consolidated shared config files with `shared/config.py` as the single entry point.
+- **Embedding batch progress logging**: `RemoteEmbeddings.embed_documents()` now logs `📤 Embedding batch X/Y texts...` for visibility into embedding throughput.
 - **Ingestion error recovery**: Workers now reclaim orphaned jobs on startup. Gatekeeper resets `PREPROCESSING` → `NEW`, Producer resets `INGESTING` → `PREPROCESSING_COMPLETE`, Consumer resets `CONSUMING` → `INGESTING`. New env var `STUCK_JOB_TIMEOUT_HOURS` (default 1). 5 unit tests.
 - **Cleanup on INGEST_FAILED**: Redis queue entries and DuckDB staged chunks are purged when a job transitions to `INGEST_FAILED`. New `RedisService.purge_queue_entries()` method.
 - **Re-ingestion after failure**: Files previously in `INGEST_FAILED` can now be re-ingested by moving them back to `staging/`. The old failure record is preserved for audit.

--- a/doc-ingest-chat/config/llama_strategy.py
+++ b/doc-ingest-chat/config/llama_strategy.py
@@ -1,5 +1,3 @@
-import os
-
 from config.settings import (
     LLAMA_CHAT_FORMAT,
     LLAMA_F16_KV,
@@ -17,23 +15,6 @@ from config.settings import (
     LLM_PATH,
 )
 
-from shared.env_names import (
-    ENV_LLAMA_CHAT_FORMAT,
-    ENV_LLAMA_F16_KV,
-    ENV_LLAMA_MAX_TOKENS,
-    ENV_LLAMA_N_BATCH,
-    ENV_LLAMA_N_CTX,
-    ENV_LLAMA_N_GPU_LAYERS,
-    ENV_LLAMA_N_THREADS,
-    ENV_LLAMA_REPEAT_PENALTY,
-    ENV_LLAMA_SEED,
-    ENV_LLAMA_TEMPERATURE,
-    ENV_LLAMA_TOP_K,
-    ENV_LLAMA_TOP_P,
-    ENV_LLAMA_VERBOSE,
-    ENV_LLM_PATH,
-)
-
 
 class LlamaParamStrategy:
     def __init__(self):
@@ -41,20 +22,20 @@ class LlamaParamStrategy:
 
     def get_params(self):
         params = {
-            "model_path": os.getenv(ENV_LLM_PATH, LLM_PATH),
-            "n_ctx": int(os.getenv(ENV_LLAMA_N_CTX, str(LLAMA_N_CTX))),
-            "n_gpu_layers": int(os.getenv(ENV_LLAMA_N_GPU_LAYERS, str(LLAMA_N_GPU_LAYERS))),
-            "n_threads": int(os.getenv(ENV_LLAMA_N_THREADS, str(LLAMA_N_THREADS))),
-            "n_batch": int(os.getenv(ENV_LLAMA_N_BATCH, str(LLAMA_N_BATCH))),
-            "f16_kv": os.getenv(ENV_LLAMA_F16_KV, str(LLAMA_F16_KV)).lower() == "true",
-            "temperature": float(os.getenv(ENV_LLAMA_TEMPERATURE, str(LLAMA_TEMPERATURE))),
-            "top_k": int(os.getenv(ENV_LLAMA_TOP_K, str(LLAMA_TOP_K))),
-            "top_p": float(os.getenv(ENV_LLAMA_TOP_P, str(LLAMA_TOP_P))),
-            "repeat_penalty": float(os.getenv(ENV_LLAMA_REPEAT_PENALTY, str(LLAMA_REPEAT_PENALTY))),
-            "max_tokens": int(os.getenv(ENV_LLAMA_MAX_TOKENS, str(LLAMA_MAX_TOKENS))),
-            "chat_format": os.getenv(ENV_LLAMA_CHAT_FORMAT, LLAMA_CHAT_FORMAT),
-            "verbose": os.getenv(ENV_LLAMA_VERBOSE, str(LLAMA_VERBOSE)).lower() == "true",
-            "seed": int(os.getenv(ENV_LLAMA_SEED, str(LLAMA_SEED))),
+            "model_path": LLM_PATH,
+            "n_ctx": LLAMA_N_CTX,
+            "n_gpu_layers": LLAMA_N_GPU_LAYERS,
+            "n_threads": LLAMA_N_THREADS,
+            "n_batch": LLAMA_N_BATCH,
+            "f16_kv": LLAMA_F16_KV,
+            "temperature": LLAMA_TEMPERATURE,
+            "top_k": LLAMA_TOP_K,
+            "top_p": LLAMA_TOP_P,
+            "repeat_penalty": LLAMA_REPEAT_PENALTY,
+            "max_tokens": LLAMA_MAX_TOKENS,
+            "chat_format": LLAMA_CHAT_FORMAT,
+            "verbose": LLAMA_VERBOSE,
+            "seed": LLAMA_SEED,
             "use_mmap": False,
         }
 

--- a/doc-ingest-chat/utils/chat_utils.py
+++ b/doc-ingest-chat/utils/chat_utils.py
@@ -6,6 +6,7 @@ Utility functions for chat formatting and citation.
 import os
 from collections import OrderedDict
 
+from config.settings import API_BASE_URL
 from langchain_core.documents import Document
 
 
@@ -30,7 +31,7 @@ def replace_citation_labels(output: str, docs: list[Document]) -> str:
 
     # Base URL for file access (linked to FastAPI backend)
     # We use localhost:8000 by default since that's where api_gpu serves /files
-    api_url = os.getenv("API_BASE_URL", "http://localhost:8000")
+    api_url = API_BASE_URL
 
     for i, doc in enumerate(docs):
         source_num = i + 1

--- a/doc-ingest-chat/utils/llm_setup.py
+++ b/doc-ingest-chat/utils/llm_setup.py
@@ -76,9 +76,14 @@ class RemoteEmbeddings(Embeddings):
         try:
             results = []
             MICRO_BATCH_SIZE = EMBEDDING_BATCH_SIZE
-            
+            total = len(texts)
+            sent = 0
+
             from more_itertools import chunked
             for micro_batch in chunked(texts, MICRO_BATCH_SIZE):
+                batch_size = len(micro_batch)
+                sent += batch_size
+                log.info(f"📤 Embedding batch {sent}/{total} texts ({batch_size} texts, {sent - batch_size + 1}-{sent})...")
                 response = self.client.embeddings.create(input=micro_batch, model=self.model_name)
                 results.extend([data.embedding for data in response.data])
             return results

--- a/doc-ingest-chat/utils/ocr_utils.py
+++ b/doc-ingest-chat/utils/ocr_utils.py
@@ -16,7 +16,7 @@ from typing import Optional, Tuple
 import cv2
 import numpy as np
 import redis
-from config.settings import MAX_OCR_DIM, OCR_ENDPOINTS, REDIS_HOST, REDIS_OCR_JOB_QUEUE, REDIS_PORT
+from config.settings import DEVICE, HF_HOME, MAX_OCR_DIM, OCR_ENDPOINTS, REDIS_HOST, REDIS_OCR_JOB_QUEUE, REDIS_PORT
 from PIL import Image
 from utils.trace_utils import get_logger, set_trace_id
 
@@ -147,7 +147,7 @@ def get_docling_converter():
             log.info(f"🚀 Initializing Docling Converter (STRICT OFFLINE MODE) cache: {CACHE_PATH}")
 
             # Modern Docling 2.x Acceleration Setup
-            device_type = os.getenv("DEVICE", "cpu").lower()
+            device_type = DEVICE.lower()
             accel_device = AcceleratorDevice.CUDA if device_type == "cuda" else AcceleratorDevice.CPU
             log.info(f"⚡ Setting Docling acceleration to: {accel_device}")
 
@@ -164,7 +164,7 @@ def get_docling_converter():
 
             # 2. LOCAL ARTIFACTS: Pointing to HF_HOME for local loading
             # This implicitly disables model downloads in Docling 2.x
-            pipeline_options.artifacts_path = os.getenv("HF_HOME", "/usr/local/model_cache")
+            pipeline_options.artifacts_path = HF_HOME
 
             # Apply modern acceleration settings
             pipeline_options.accelerator_options = AcceleratorOptions(

--- a/doc-ingest-chat/utils/text_utils.py
+++ b/doc-ingest-chat/utils/text_utils.py
@@ -11,7 +11,7 @@ import unicodedata
 from typing import Any
 
 import regex  # third-party regex with Unicode script support
-from config.settings import ALLOW_LATIN_EXTENDED, EMBEDDING_ENDPOINTS, LATIN_SCRIPT_MIN_RATIO
+from config.settings import ALLOW_LATIN_EXTENDED, EMBEDDING_ENDPOINTS, HF_HUB_OFFLINE, LATIN_SCRIPT_MIN_RATIO
 from ftfy import fix_text
 from transformers import AutoTokenizer
 
@@ -28,7 +28,7 @@ def get_tokenizer():
         try:
             model_path = EMBEDDING_ENDPOINTS
             # Determine if we should allow remote downloads
-            hub_offline = os.getenv("HF_HUB_OFFLINE", "0") == "1"
+            hub_offline = HF_HUB_OFFLINE == "1"
             local_only = hub_offline
 
             if model_path.startswith(("http://", "https://")):

--- a/doc-ingest-chat/workers/whisperx_worker.py
+++ b/doc-ingest-chat/workers/whisperx_worker.py
@@ -22,18 +22,20 @@ import time
 import traceback
 
 import redis
-from utils.trace_utils import get_logger, set_trace_id
 
 # Minimal config for the worker - can be overridden by ENV
-REDIS_HOST = os.getenv("REDIS_HOST", "redis")
-REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
-REDIS_WHISPER_JOB_QUEUE = os.getenv("REDIS_WHISPER_JOB_QUEUE", "whisper_processing_job")
+from config.settings import (
+    COMPUTE_TYPE,
+    DEVICE,
+    MEDIA_BATCH_SIZE,
+    REDIS_HOST,
+    REDIS_PORT,
+    REDIS_WHISPER_JOB_QUEUE,
+    WHISPER_MODEL_ENDPOINTS,
+)
+from utils.trace_utils import get_logger, set_trace_id
 
-# WhisperX specific settings
-DEVICE = os.getenv("DEVICE", "cuda")
-COMPUTE_TYPE = os.getenv("COMPUTE_TYPE", "float16")
-BATCH_SIZE = int(os.getenv("MEDIA_BATCH_SIZE", 8))
-WHISPER_MODEL_ENDPOINTS = os.getenv("WHISPER_MODEL_ENDPOINTS", "/models/whisper")
+BATCH_SIZE = MEDIA_BATCH_SIZE
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 log = get_logger("whisperx_worker")

--- a/openspec/changes/unify-worker-settings/.openspec.yaml
+++ b/openspec/changes/unify-worker-settings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/unify-worker-settings/design.md
+++ b/openspec/changes/unify-worker-settings/design.md
@@ -1,0 +1,38 @@
+## Context
+
+The shared settings system (`shared/config.py`) provides lazy-loaded environment variables with canonical defaults from `shared/defaults.py`. Workers and utilities should load settings via `from config.settings import NAME`, which triggers `_SETTINGS[NAME]()` — a lambda that calls `os.getenv(ENV_NAME, DEFAULT_VALUE)` at access time. This ensures env var priority over defaults and lazy resolution.
+
+An audit found 15+ direct `os.getenv()` calls across 6+ modules that bypass this system. Some settings in `shared/config.py` may be dead (no longer consumed). Some env vars used directly may not have entries in the shared system at all.
+
+## Goals / Non-Goals
+
+**Goals:**
+- All modules load configuration through `config.settings`
+- Missing env vars added to the shared system
+- Dead entries removed from the shared system
+- `env_names.py`, `defaults.py`, `config.py` in sync
+- No functional changes to any setting values or env var names
+
+**Non-Goals:**
+- No changes to the lazy-loading mechanism itself
+- No renames of existing env vars
+- No changes to the `config/settings.py` re-export layer
+
+## Decisions
+
+1. **Audit first, then fix**: List all direct `os.getenv()` calls and all `_SETTINGS` entries. Cross-reference to find what needs adding and what needs removing.
+
+2. **Replace, don't wrap**: Each `os.getenv("KEY", default)` becomes `from config.settings import KEY`. The shared system's lazy lambda resolves the value. No inline overrides needed — the lambda already applies `os.getenv(ENV_NAME, DEFAULT_VALUE)`.
+
+3. **Consolidation of shared files**: `shared/env_names.py` and `shared/defaults.py` are implementation details consumed only by `shared/config.py`. No module outside `shared/` shall import from them directly. After consolidation, `config.settings` (the re-export layer) is the only import path for all workers.
+
+4. **`llama_strategy.py` needs cleanup**: It currently imports `DEFAULT_LLAMA_USE_GPU` from `shared.defaults` and `ENV_LLAMA_USE_GPU` from `shared.env_names` directly. These must be replaced with imports from `config.settings`.
+
+5. **`HAPROXY_SUPERVISOR_ENDPOINTS` is special**: This env var is set dynamically by `run-compose.sh` and read by `gatekeeper_logic.py`. It follows a different pattern — set by the compose script, not by user config. Leave as direct `os.environ.get()` unless a strong case exists to move it.
+
+6. **Dead entry detection**: An entry in `_SETTINGS` is dead if no module imports it via `from config.settings import X` AND no module references it via `settings.X`. Grep the entire `doc-ingest-chat/` tree to confirm.
+
+## Risks / Trade-offs
+
+- **Import order**: `config.settings` must be imported after the sys.path fix in each worker. Follow the existing pattern from other workers.
+- **Backward compatibility**: All existing env var names remain valid. Only the import mechanism changes. No defaults change.

--- a/openspec/changes/unify-worker-settings/proposal.md
+++ b/openspec/changes/unify-worker-settings/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Multiple workers and utility modules read environment variables directly via `os.getenv()` with inline defaults, bypassing the shared lazy-loaded settings system (`shared/config.py` → `config/settings.py`). This causes default drift (e.g., `MEDIA_BATCH_SIZE` defaulted to 16 in whisperx_worker while `shared/defaults.py` had 8), inconsistent configuration resolution, and settings that are resolved at module import time instead of lazily. Additionally, `shared/config.py` may contain entries that are no longer consumed, and may be missing entries for env vars that workers read directly.
+
+## What Changes
+
+- Audit all workers, handlers, utils, and services for direct `os.getenv()` / `os.environ.get()` calls
+- Replace each direct call with an import from `config.settings` (env var priority, shared default fallback)
+- Consolidate `shared/defaults.py` and `shared/env_names.py` INTO `shared/config.py` — `config.py` is the single entry point. The other two become implementation details consumed only by `config.py`, not imported directly by workers.
+- Move any env var entries that workers read directly but aren't in the shared system into `config.py`
+- Remove dead entries from all three shared files
+- No module outside `shared/` shall import from `shared.defaults` or `shared.env_names` directly — only through `shared.config` or `config.settings`
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `infrastructure`: The "Environment variable configuration" requirement changes — all workers MUST load settings through `config.settings`, not via direct `os.getenv()` calls. The shared settings files must be kept in sync with each other and pruned of dead entries.
+
+## Impact
+
+- `doc-ingest-chat/workers/whisperx_worker.py`: 6 direct `os.getenv()` calls → imports from `config.settings`
+- `doc-ingest-chat/utils/ocr_utils.py`: 2 direct `os.getenv()` calls → imports from `config.settings`
+- `doc-ingest-chat/utils/chat_utils.py`: 2 direct `os.getenv()` calls → imports from `config.settings`
+- `doc-ingest-chat/utils/text_utils.py`: 1 direct `os.getenv()` call → import from `config.settings`
+- `doc-ingest-chat/utils/warmup.py`: 1 direct `os.environ.get()` call → import from `config.settings`
+- `doc-ingest-chat/workers/gatekeeper_logic.py`: 1 direct `os.environ.get("HAPROXY_SUPERVISOR_ENDPOINTS")` call
+- `shared/env_names.py`: Consolidated INTO `shared/config.py`. No module outside `shared/` may import from this directly.
+- `shared/defaults.py`: Consolidated INTO `shared/config.py`. No module outside `shared/` may import from this directly.
+- `shared/config.py`: Becomes the single source of truth. Workers import from `config.settings` which delegates here.
+- `doc-ingest-chat/config/llama_strategy.py`: Remove direct `shared.defaults` and `shared.env_names` imports — must use `config.settings` instead.

--- a/openspec/changes/unify-worker-settings/specs/infrastructure/spec.md
+++ b/openspec/changes/unify-worker-settings/specs/infrastructure/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Environment variable configuration
+
+The system SHALL support 60+ environment variables for configuration. Critical required variables SHALL include: DEFAULT_DOC_INGEST_ROOT, EMBEDDING_ENDPOINTS, LLM_PATH, SUPERVISOR_LLM_ENDPOINTS. Missing required variables SHALL cause a CRITICAL ERROR message and sys.exit(1). Variables SHALL be loaded lazily on first access.
+
+All workers, handlers, utils, and services SHALL load their configuration through `from config.settings import <NAME>`, which resolves the value lazily with env var priority over the canonical default. Direct `os.getenv()` calls with inline defaults SHALL NOT be used — they bypass the shared system and allow defaults to drift.
+
+The three shared files (`shared/env_names.py`, `shared/defaults.py`, `shared/config.py`) SHALL be kept in sync. Dead entries (env var constants or settings that no module consumes) SHALL be removed. Missing entries for env vars that modules read directly SHALL be added.
+
+#### Scenario: Missing required variable
+- **WHEN** a required environment variable is not set
+- **THEN** the system SHALL log "CRITICAL ERROR: Environment variable '{key}' is NOT set." and exit
+
+#### Scenario: Lazy loading
+- **WHEN** a setting is accessed
+- **THEN** it SHALL be resolved from the environment at access time, not at import time
+
+#### Scenario: Worker loads setting via shared config
+- **WHEN** a worker needs a configuration value
+- **THEN** it SHALL import it from `config.settings` rather than calling `os.getenv()` directly

--- a/openspec/changes/unify-worker-settings/tasks.md
+++ b/openspec/changes/unify-worker-settings/tasks.md
@@ -1,0 +1,42 @@
+## 1. Consolidate Shared Files
+
+- [x] 1.1 Audit complete — only `llama_strategy.py` imports from `shared.env_names` directly (no imports from `shared.defaults` outside `shared/`)
+- [x] 1.2 Audit complete — 3 missing _SETTINGS entries (HF_HOME, HF_HUB_OFFLINE, API_BASE_URL)
+- [x] 1.3 Verified: env_names and defaults exist for all doc-ingest settings. 3 _SETTINGS entries added.
+
+## 2. Llama Strategy Cleanup
+
+- [x] 2.1 `llama_strategy.py` — removed direct `shared.env_names` import, uses `config.settings` values directly (no redundant os.getenv wrapper)
+- [x] 2.2 Verified: no modules outside `shared/` import from `shared.defaults` or `shared.env_names` directly
+
+## 3. WhisperX Worker
+
+- [x] 3.1 Replaced 7 direct `os.getenv()` calls with imports from `config.settings`
+
+## 4. OCR Utils
+
+- [x] 4.1 Replaced `os.getenv("DEVICE", "cpu")` and `os.getenv("HF_HOME", ...)` with `config.settings`
+
+## 5. Chat Utils
+
+- [x] 5.1 Replaced `os.getenv("API_BASE_URL", ...)` with import from `config.settings`
+
+## 6. Text Utils
+
+- [x] 6.1 Replaced `os.getenv("HF_HUB_OFFLINE", "0")` with import from `config.settings`
+
+## 7. Warmup
+
+- [x] 7.1 Reverted — warmup runs during Docker build where config.settings isn't available. Kept `os.environ.get("OCR_ENDPOINTS", "LOCAL")` as-is.
+
+## 8. Shared Config Sync and Cleanup
+
+- [x] 8.1 Added `ENV_API_BASE_URL`, `ENV_HF_HOME`, `ENV_HF_HUB_OFFLINE` to `shared/env_names.py` imports in `config.py`
+- [x] 8.2 Added `DEFAULT_API_BASE_URL`, `DEFAULT_HF_HUB_OFFLINE` to `shared/defaults.py` imports in `config.py`
+- [x] 8.3 Added `API_BASE_URL`, `HF_HOME`, `HF_HUB_OFFLINE` to `_SETTINGS` dict
+- [x] 8.4 No dead entries found — all _SETTINGS keys are either imported or referenced via `from config import settings`
+
+## 9. Verification
+
+- [x] 9.1 `ruff check` — clean
+- [x] 9.2 Full pytest suite — 142/142 passed

--- a/openspec/specs/infrastructure/spec.md
+++ b/openspec/specs/infrastructure/spec.md
@@ -34,6 +34,10 @@ The system SHALL provide separate Docker images for standard workers (Dockerfile
 
 The system SHALL support 60+ environment variables for configuration. Critical required variables SHALL include: DEFAULT_DOC_INGEST_ROOT, EMBEDDING_ENDPOINTS, LLM_PATH, SUPERVISOR_LLM_ENDPOINTS. Missing required variables SHALL cause a CRITICAL ERROR message and sys.exit(1). Variables SHALL be loaded lazily on first access.
 
+All workers, handlers, utils, and services SHALL load their configuration through `from config.settings import <NAME>`, which resolves the value lazily with env var priority over the canonical default. Direct `os.getenv()` calls with inline defaults SHALL NOT be used — they bypass the shared system and allow defaults to drift.
+
+The three shared files (`shared/env_names.py`, `shared/defaults.py`, `shared/config.py`) SHALL be kept in sync. Dead entries (env var constants or settings that no module consumes) SHALL be removed. Missing entries for env vars that modules read directly SHALL be added.
+
 #### Scenario: Missing required variable
 - **WHEN** a required environment variable is not set
 - **THEN** the system SHALL log "CRITICAL ERROR: Environment variable '{key}' is NOT set." and exit
@@ -41,6 +45,10 @@ The system SHALL support 60+ environment variables for configuration. Critical r
 #### Scenario: Lazy loading
 - **WHEN** a setting is accessed
 - **THEN** it SHALL be resolved from the environment at access time, not at import time
+
+#### Scenario: Worker loads setting via shared config
+- **WHEN** a worker needs a configuration value
+- **THEN** it SHALL import it from `config.settings` rather than calling `os.getenv()` directly
 
 ### Requirement: Startup and warmup sequencing
 

--- a/shared/config.py
+++ b/shared/config.py
@@ -15,6 +15,7 @@ from typing import Any, Callable
 
 from shared.defaults import (
     DEFAULT_ALLOW_LATIN_EXTENDED,
+    DEFAULT_API_BASE_URL,
     DEFAULT_CHUNK_OVERLAP,
     DEFAULT_CHUNK_SIZE,
     DEFAULT_CHUNK_TIMEOUT,
@@ -24,6 +25,7 @@ from shared.defaults import (
     DEFAULT_FORCE_MARKDOWN_LLM,
     DEFAULT_GATEKEEPER_BATCH_SIZE,
     DEFAULT_HA_INTERLEAVE,
+    DEFAULT_HF_HUB_OFFLINE,
     DEFAULT_LATIN_SCRIPT_MIN_RATIO,
     DEFAULT_LLAMA_CHAT_FORMAT,
     DEFAULT_LLAMA_F16_KV,
@@ -75,6 +77,7 @@ from shared.defaults import (
 )
 from shared.env_names import (
     ENV_ALLOW_LATIN_EXTENDED,
+    ENV_API_BASE_URL,
     ENV_CHROMA_COLLECTION,
     ENV_CHROMA_HOST,
     ENV_CHROMA_PORT,
@@ -95,6 +98,8 @@ from shared.env_names import (
     ENV_GATEKEEPER_BATCH_SIZE,
     ENV_GATEKEEPER_FAILURE_DB,
     ENV_HA_INTERLEAVE,
+    ENV_HF_HOME,
+    ENV_HF_HUB_OFFLINE,
     ENV_INGESTED_FILE,
     ENV_INGESTION_DIR,
     ENV_LATIN_SCRIPT_MIN_RATIO,
@@ -416,6 +421,12 @@ _SETTINGS: dict[str, Callable[[], Any]] = {
     "SESSION_TTL_HOURS": lambda: int(os.getenv(ENV_SESSION_TTL_HOURS, str(DEFAULT_SESSION_TTL_HOURS))),
     # Hours before a job stuck in an intermediate state is eligible for reclaim
     "STUCK_JOB_TIMEOUT_HOURS": lambda: int(os.getenv(ENV_STUCK_JOB_TIMEOUT_HOURS, str(DEFAULT_STUCK_JOB_TIMEOUT_HOURS))),
+    # Base URL for chat API (frontend-facing)
+    "API_BASE_URL": lambda: os.getenv(ENV_API_BASE_URL, DEFAULT_API_BASE_URL),
+    # Cache directory for HuggingFace models
+    "HF_HOME": lambda: os.getenv(ENV_HF_HOME, "/usr/local/model_cache"),
+    # HuggingFace offline mode
+    "HF_HUB_OFFLINE": lambda: os.getenv(ENV_HF_HUB_OFFLINE, DEFAULT_HF_HUB_OFFLINE),
 }
 
 


### PR DESCRIPTION
Replaces direct os.getenv() calls across all workers with shared lazy-loaded config.settings imports. Adds missing API_BASE_URL, HF_HOME, HF_HUB_OFFLINE to shared config. Adds embedding batch progress logging.